### PR TITLE
[DNM] update Parent::BlockTransaction to include the block header and output

### DIFF
--- a/api/src/endpoints.rs
+++ b/api/src/endpoints.rs
@@ -76,11 +76,10 @@ impl ApiEndpoint for OutputApi {
 		debug!("GET output {}", id);
 		let c = util::from_hex(id.clone()).map_err(|_| Error::Argument(format!("Not a valid commitment: {}", id)))?;
 
-    match self.chain.get_unspent(&Commitment::from_vec(c)) {
-      Some(utxo) => Ok(utxo),
-      None => Err(Error::NotFound),
-    }
-
+    	match self.chain.get_unspent(&Commitment::from_vec(c)) {
+      		Some((output, _)) => Ok(output),
+      		None => Err(Error::NotFound),
+    	}
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -38,7 +38,7 @@ bitflags! {
 }
 
 /// Block header, fairly standard compared to other blockchains.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BlockHeader {
 	/// Height of this block since the genesis block (height 0)
 	pub height: u64,

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -19,6 +19,7 @@ use std::thread;
 use chain::{self, ChainAdapter};
 use core::core::{self, Output};
 use core::core::hash::{Hash, Hashed};
+use core::core::block::BlockHeader;
 use core::core::target::Difficulty;
 use p2p::{self, NetAdapter, Server, PeerStore, PeerData, State};
 use pool;
@@ -294,5 +295,9 @@ impl PoolToChainAdapter {
 impl pool::BlockChain for PoolToChainAdapter {
 	fn get_unspent(&self, output_ref: &Commitment) -> Option<Output> {
 		self.chain.borrow().get_unspent(output_ref)
+	}
+
+	fn get_block_header_for_output(&self, output_ref: &Commitment) -> Option<BlockHeader> {
+		self.chain.borrow().get_block_header_for_output(output_ref)
 	}
 }

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -293,11 +293,7 @@ impl PoolToChainAdapter {
 }
 
 impl pool::BlockChain for PoolToChainAdapter {
-	fn get_unspent(&self, output_ref: &Commitment) -> Option<Output> {
+	fn get_unspent(&self, output_ref: &Commitment) -> Option<(Output, BlockHeader)> {
 		self.chain.borrow().get_unspent(output_ref)
-	}
-
-	fn get_block_header_for_output(&self, output_ref: &Commitment) -> Option<BlockHeader> {
-		self.chain.borrow().get_block_header_for_output(output_ref)
 	}
 }

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -93,6 +93,11 @@ impl BlockChain for DummyChainImpl {
     fn get_unspent(&self, commitment: &Commitment) -> Option<transaction::Output> {
         self.utxo.read().unwrap().get_output(commitment).cloned()
     }
+
+    fn get_block_header_for_output(&self, _commitment: &Commitment) -> Option<block::BlockHeader> {
+        // TODO - this is clearly not the right block header
+        Some(block::BlockHeader::default())
+    }
 }
 
 impl DummyChain for DummyChainImpl {

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -90,13 +90,14 @@ impl DummyChainImpl {
 }
 
 impl BlockChain for DummyChainImpl {
-    fn get_unspent(&self, commitment: &Commitment) -> Option<transaction::Output> {
-        self.utxo.read().unwrap().get_output(commitment).cloned()
-    }
-
-    fn get_block_header_for_output(&self, _commitment: &Commitment) -> Option<block::BlockHeader> {
-        // TODO - this is clearly not the right block header
-        Some(block::BlockHeader::default())
+    fn get_unspent(&self, commitment: &Commitment) -> Option<(transaction::Output, block::BlockHeader)> {
+        let utxo_set = self.utxo.read().unwrap();
+        let output = utxo_set.get_output(commitment);
+        let header = block::BlockHeader::default();
+        match output {
+            Some(&out) => Some((out, header)),
+            None => None
+        }
     }
 }
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -77,14 +77,9 @@ impl<T> TransactionPool<T> where T: BlockChain {
     // output designated by output_commitment.
     fn search_blockchain_unspents(&self, output_commitment: &Commitment) -> Option<Parent> {
         self.blockchain.get_unspent(output_commitment).
-            map(|output| match self.pool.get_blockchain_spent(output_commitment) {
+            map(|(output, header)| match self.pool.get_blockchain_spent(output_commitment) {
                 Some(x) => Parent::AlreadySpent{other_tx: x.destination_hash().unwrap()},
-                None => {
-                    match self.blockchain.get_block_header_for_output(output_commitment) {
-                        Some(header) => Parent::BlockTransaction{header, output},
-                        None => Parent::Unknown // TODO - what to return here (impossible situation?)
-                    }
-                }
+                None => Parent::BlockTransaction{header, output}
             })
     }
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -77,9 +77,14 @@ impl<T> TransactionPool<T> where T: BlockChain {
     // output designated by output_commitment.
     fn search_blockchain_unspents(&self, output_commitment: &Commitment) -> Option<Parent> {
         self.blockchain.get_unspent(output_commitment).
-            map(|_| match self.pool.get_blockchain_spent(output_commitment) {
+            map(|output| match self.pool.get_blockchain_spent(output_commitment) {
                 Some(x) => Parent::AlreadySpent{other_tx: x.destination_hash().unwrap()},
-                None => Parent::BlockTransaction,
+                None => {
+                    match self.blockchain.get_block_header_for_output(output_commitment) {
+                        Some(header) => Parent::BlockTransaction{header, output},
+                        None => Parent::Unknown // TODO - what to return here (impossible situation?)
+                    }
+                }
             })
     }
 
@@ -109,7 +114,7 @@ impl<T> TransactionPool<T> where T: BlockChain {
 
     /// Attempts to add a transaction to the pool.
     ///
-    /// Adds a transation to the memory pool, deferring to the orphans pool
+    /// Adds a transaction to the memory pool, deferring to the orphans pool
     /// if necessary, and performing any connection-related validity checks.
     /// Happens under an exclusive mutable reference gated by the write portion
     /// of a RWLock.
@@ -132,7 +137,6 @@ impl<T> TransactionPool<T> where T: BlockChain {
             return Err(PoolError::AlreadyInPool)
         }
 
-
         // The next issue is to identify all unspent outputs that
         // this transaction will consume and make sure they exist in the set.
         let mut pool_refs: Vec<graph::Edge> = Vec::new();
@@ -149,7 +153,17 @@ impl<T> TransactionPool<T> where T: BlockChain {
             // into the pool.
             match self.search_for_best_output(&input.commitment()) {
                 Parent::PoolTransaction{tx_ref: x} => pool_refs.push(base.with_source(Some(x))),
-                Parent::BlockTransaction => blockchain_refs.push(base),
+                Parent::BlockTransaction{header, output} => {
+                    println!("height of block for output - {}", header.height);
+                    println!("output features (is it a coinbase?) - {:?}", output.features);
+
+                    // TODO - we need the height of the current block I guess...
+
+                    // if coinbase output has not matured -
+                    // PoolError::ImmatureCoinbase(header, output.commitment())
+
+                    blockchain_refs.push(base)
+                }
                 Parent::Unknown => orphan_refs.push(base),
                 Parent::AlreadySpent{other_tx: x} => return Err(PoolError::DoubleSpend{other_tx: x, spent_output: input.commitment()}),
             }
@@ -540,7 +554,7 @@ mod tests {
             expect_output_parent!(read_pool,
                 Parent::AlreadySpent{other_tx: _}, 11, 5);
             expect_output_parent!(read_pool,
-                Parent::BlockTransaction, 8);
+                Parent::BlockTransaction{header: _, output: _}, 8);
             expect_output_parent!(read_pool,
                 Parent::Unknown, 20);
 
@@ -750,7 +764,7 @@ mod tests {
             assert_eq!(read_pool.total_size(), 4);
 
             // We should have available blockchain outputs at 9 and 3
-            expect_output_parent!(read_pool, Parent::BlockTransaction, 9, 3);
+            expect_output_parent!(read_pool, Parent::BlockTransaction{header: _, output: _}, 9, 3);
 
             // We should have spent blockchain outputs at 4 and 7
             expect_output_parent!(read_pool,

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -104,10 +104,7 @@ pub trait BlockChain {
   /// is spent or if it doesn't exist. The blockchain is expected to produce
   /// a result with its current view of the most worked chain, ignoring
   /// orphans, etc.
-  fn get_unspent(&self, output_ref: &Commitment) -> Option<transaction::Output>;
-
-  /// Get the block header for an output by its commitment.
-  fn get_block_header_for_output(&self, output_ref: &Commitment) -> Option<block::BlockHeader>;
+  fn get_unspent(&self, output_ref: &Commitment) -> Option<(transaction::Output, block::BlockHeader)>;
 }
 
 /// Pool contains the elements of the graph that are connected, in full, to


### PR DESCRIPTION
Rough spike to see if we can get enough info/context in `add_to_memory_pool ` to be able to verify the "maturity" of a coinbase output being spent in the new txn.

1) This is throwaway - I'm not sure `add_to_memory_pool` is even the right place to start checking this.
2) I'm not sure adding `output` and `header` to `Parent::BlockTransaction` makes sense - does this leak dependencies too much into `pool`?
