### PR TITLE
[WIP] ensure coinbase cannot be spent for X blocks

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -253,8 +253,12 @@ impl Chain {
 	}
 
 	/// Block header for the chain head
-	pub fn head_header(&self) -> Result<BlockHeader, Error> {
-		self.store.head_header().map_err(&Error::StoreErr)
+	pub fn head_header(&self) -> Option<BlockHeader> {
+		let header = self.store.head_header();
+        match header {
+            Ok(h) => Some(h),
+            Err(_) => None,
+        }
 	}
 
 	/// Gets a block header by hash

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -214,7 +214,7 @@ impl Chain {
     /// Gets an unspent output from its commitment. With return None if the
 	/// output
 	/// doesn't exist or has been spent. This querying is done in a way that's
-	/// constistent with the current chain state and more specifically the
+	/// consistent with the current chain state and more specifically the
 	/// current
 	/// branch it is on in case of forks.
 	pub fn get_unspent(&self, output_ref: &Commitment) -> Option<Output> {
@@ -275,7 +275,7 @@ impl Chain {
 	}
 
     /// Gets the block header by the provided output commitment
-    pub fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Result<BlockHeader, Error> {
+    pub fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Option<BlockHeader> {
         self.store.get_block_header_by_output_commit(commit).map_err(
             &Error::StoreErr,
         )

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -276,9 +276,11 @@ impl Chain {
 
     /// Gets the block header by the provided output commitment
     pub fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Option<BlockHeader> {
-        self.store.get_block_header_by_output_commit(commit).map_err(
-            &Error::StoreErr,
-        )
+        let header = self.store.get_block_header_by_output_commit(commit);
+        match header {
+            Ok(h) => Some(h),
+            Err(_) => None,
+        }
     }
 
 	/// Get the tip of the header chain

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -179,13 +179,13 @@ fn validate_block(block: &Block, ctx: &mut BlockContext) -> Result<(), Error> {
 	for input in &block.inputs {
 		// TODO check every input exists as a UTXO using the UTXO index
 
-		// now check any coinbase inputs have sufficently matured
+		// now check that any coinbase inputs have matured sufficiently
 		if let Ok(output) = ctx.store.get_output_by_commit(&input.commitment()) {
 			if output.features.contains(transaction::COINBASE_OUTPUT) {
 				if let Ok(output_header) = ctx.store.get_block_header_by_output_commit(&input.commitment()) {
 					// TODO - make sure we are not off-by-1 here vs. the equivalent tansaction validation rule
 					if block.header.height <= output_header.height + consensus::COINBASE_MATURITY {
-						// TODO - here we need to blow up with ImmatureCoinbase
+						return Err(Error::ImmatureCoinbase);
 					}
 				};
 			};

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -57,6 +57,8 @@ pub enum Error {
 	InvalidBlockTime,
 	/// Block height is invalid (not previous + 1)
 	InvalidBlockHeight,
+    /// coinbase can only be spent after it has matured (n blocks)
+    ImmatureCoinbase,
 	/// Internal issue when trying to save or load data from store
 	StoreErr(grin_store::Error),
 	/// Error serializing or deserializing a type

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -26,6 +26,9 @@ use core::target::Difficulty;
 /// The block subsidy amount
 pub const REWARD: u64 = 1_000_000_000;
 
+/// Number of blocks before a coinbase matures and can be spent
+pub const COINBASE_MATURITY: u64 = 1_000;
+
 /// Block interval, in seconds, the network will tune its next_target for. Note
 /// that we may reduce this value in the future as we get more data on mining
 /// with Cuckoo Cycle, networks improve and block propagation is optimized
@@ -192,15 +195,15 @@ mod test {
 	fn next_target_adjustment() {
 		// not enough data
 		assert_eq!(next_difficulty(vec![]).unwrap(), Difficulty::from_num(MINIMUM_DIFFICULTY));
-		
+
 		assert_eq!(next_difficulty(vec![Ok((60, Difficulty::one()))]).unwrap(),
 		           Difficulty::from_num(MINIMUM_DIFFICULTY));
-				   
+
 		assert_eq!(next_difficulty(repeat(60, 10, DIFFICULTY_ADJUST_WINDOW)).unwrap(),
 		           Difficulty::from_num(MINIMUM_DIFFICULTY));
 
 		// just enough data, right interval, should stay constant
-		
+
 		let just_enough = DIFFICULTY_ADJUST_WINDOW + MEDIAN_TIME_WINDOW;
 		assert_eq!(next_difficulty(repeat(60, 1000, just_enough)).unwrap(),
 		           Difficulty::from_num(1000));

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -18,6 +18,7 @@ use std::thread;
 
 use chain::{self, ChainAdapter};
 use core::core::{self, Output};
+use core::core::block::BlockHeader;
 use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
 use p2p::{self, NetAdapter, Server, PeerStore, PeerData, State};
@@ -294,5 +295,9 @@ impl PoolToChainAdapter {
 impl pool::BlockChain for PoolToChainAdapter {
 	fn get_unspent(&self, output_ref: &Commitment) -> Option<Output> {
 		self.chain.borrow().get_unspent(output_ref)
+	}
+
+	fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Option<BlockHeader> {
+		self.chain.borrow().get_block_header_by_output_commit(commit)
 	}
 }

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -300,4 +300,8 @@ impl pool::BlockChain for PoolToChainAdapter {
 	fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Option<BlockHeader> {
 		self.chain.borrow().get_block_header_by_output_commit(commit)
 	}
+
+	fn head_header(&self) -> Option<BlockHeader> {
+		self.chain.borrow().head_header()
+	}
 }

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -95,11 +95,14 @@ impl BlockChain for DummyChainImpl {
     }
 
     // TODO - this is not right
-    fn get_block_header_by_output_commit(&self, _: &Commitment)
-        -> Option<block::BlockHeader> {
-            Some(block::BlockHeader::default())
+    fn get_block_header_by_output_commit(&self, _: &Commitment) -> Option<block::BlockHeader> {
+        Some(block::BlockHeader::default())
     }
 
+    // TODO - this is not right
+    fn head_header(&self) -> Option<block::BlockHeader> {
+        Some(block::BlockHeader::default())
+    }
 }
 
 impl DummyChain for DummyChainImpl {

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -93,6 +93,13 @@ impl BlockChain for DummyChainImpl {
     fn get_unspent(&self, commitment: &Commitment) -> Option<transaction::Output> {
         self.utxo.read().unwrap().get_output(commitment).cloned()
     }
+
+    // TODO - this is not right
+    fn get_block_header_by_output_commit(&self, _: &Commitment)
+        -> Option<block::BlockHeader> {
+            Some(block::BlockHeader::default())
+    }
+
 }
 
 impl DummyChain for DummyChainImpl {

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -149,9 +149,14 @@ impl<T> TransactionPool<T> where T: BlockChain {
             match self.search_for_best_output(&input.commitment()) {
                 Parent::PoolTransaction{tx_ref: x} => pool_refs.push(base.with_source(Some(x))),
                 Parent::BlockTransaction{output} => {
+                    // TODO - pull this out into a separate function
+
                     println!("output features - {:?}", output.features);
 
-                    let header = self.blockchain.get_block_header_by_output_commit(&output.commitment());
+                    if output.features.contains(transaction::COINBASE_OUTPUT) {
+                        let out_header = self.blockchain.get_block_header_by_output_commit(&output.commitment());
+                        let head_header = self.blockchain.head_header();
+                    };
 
                     blockchain_refs.push(base)
                 },

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -20,7 +20,7 @@ pub use graph;
 use core::core::transaction;
 use core::core::block;
 use core::core::hash;
-use core::consensus::COINBASE_MATURITY;
+use core::consensus;
 
 use secp;
 use secp::pedersen::Commitment;
@@ -153,8 +153,7 @@ impl<T> TransactionPool<T> where T: BlockChain {
                     if output.features.contains(transaction::COINBASE_OUTPUT) {
                         if let Some(out_header) = self.blockchain.get_block_header_by_output_commit(&output.commitment()) {
                             if let Some(head_header) = self.blockchain.head_header() {
-                                let diff = head_header.height - out_header.height;
-                                if diff < COINBASE_MATURITY {
+                                if head_header.height <= out_header.height + consensus::COINBASE_MATURITY {
                                     return Err(PoolError::ImmatureCoinbase{
                                         header: out_header,
                                         output: output.commitment()

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -101,9 +101,12 @@ pub trait BlockChain {
   /// orphans, etc.
   fn get_unspent(&self, output_ref: &Commitment) -> Option<transaction::Output>;
 
-  /// Get the block header by outputcommitment.
+  /// Get the block header by output commitment (needed for spending coinbase after n blocks)
   /// TODO - is this breaking encapsulation too much?
   fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Option<block::BlockHeader>;
+
+  /// TODO - again, are we breaking encapsulation here?
+  fn head_header(&self) -> Option<block::BlockHeader>;
 }
 
 /// Pool contains the elements of the graph that are connected, in full, to

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -89,6 +89,13 @@ pub enum PoolError {
         /// The spent output
         spent_output: Commitment
     },
+    /// Attempt to spend a coinbase output before it matures (1000 blocks?)
+    ImmatureCoinbase{
+        /// The block header of the block containing the coinbase output
+        header: block::BlockHeader,
+        /// The unspent coinbase output
+        output: Commitment,
+    },
     /// An orphan successfully added to the orphans set
     OrphanTransaction,
 }

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -24,6 +24,7 @@ use secp::pedersen::Commitment;
 
 pub use graph;
 
+use core::core::block;
 use core::core::transaction;
 use core::core::hash;
 
@@ -46,7 +47,7 @@ pub struct TxSource {
 #[derive(Clone)]
 pub enum Parent {
     Unknown,
-    BlockTransaction,
+    BlockTransaction{output: transaction::Output},
     PoolTransaction{tx_ref: hash::Hash},
     AlreadySpent{other_tx: hash::Hash},
 }
@@ -55,7 +56,7 @@ impl fmt::Debug for Parent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             &Parent::Unknown => write!(f, "Parent: Unknown"),
-            &Parent::BlockTransaction => write!(f, "Parent: Block Transaction"),
+            &Parent::BlockTransaction{output: _} => write!(f, "Parent: Block Transaction"),
             &Parent::PoolTransaction{tx_ref: x} => write!(f,
                 "Parent: Pool Transaction ({:?})", x),
             &Parent::AlreadySpent{other_tx: x} => write!(f,
@@ -99,6 +100,10 @@ pub trait BlockChain {
   /// a result with its current view of the most worked chain, ignoring
   /// orphans, etc.
   fn get_unspent(&self, output_ref: &Commitment) -> Option<transaction::Output>;
+
+  /// Get the block header by outputcommitment.
+  /// TODO - is this breaking encapsulation too much?
+  fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Option<block::BlockHeader>;
 }
 
 /// Pool contains the elements of the graph that are connected, in full, to


### PR DESCRIPTION
* modify `get_block_header_by_output_commit` to return `Option<BlockHeader>` (avoid exposing chain errors to pool)
* modified `head_header` to return `Option<BlockHeader>` (avoid exposing chain errors to pool)
* use `get_block_header_by_output_commit` and `head_header` in `add_to_memory_pool`
* introduce `COINBASE_MATURITY` const in consensus
* introduce `PoolError::ImmatureCoinbase`
* return `output` in `Parent::BlockTransaction`
* add same coinbase maturity check to `validate_block`

TODO - 
- [x] add similar consensus check when adding a new block - `validate_block()` I think?
- [ ] confirm we are not off-by-1 on block validation vs. txn validation rules
- [ ] test coverage around `add_to_memory_pool` to cover `ImmatureCoinbase` path
- [ ] test coverage around `validate_block` to cover `ImmatureCoinbase` path


